### PR TITLE
Add support for multiple-level subdomain by taking always the first before `.`

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,8 +36,7 @@ function maybe_bounce(req, res, bounce) {
     if (!subdomain) {
         return false;
     }
-
-    var client_id = subdomain;
+    var client_id = subdomain.split('.')[0];
     var client = clients[client_id];
 
     // no such subdomain


### PR DESCRIPTION
Will allow domains as `my-localtunnel.mydomain.com` creating tunnels in the format `xxsasdjasj.my-localtunnel.mydomain.com`.

But, since we only care of the first `xxsasdjasj` part of the subdomain `xxsasdjasj.my-localtunnel`, with

``` js
var client_id = subdomain.split('.')[0];
```

should be enough.
