### PR TITLE
Add subdomain option

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -16,6 +16,10 @@ var argv = optimist
         default: '80',
         describe: 'listen on this port for outside requests'
     })
+    .options('subdomain', {
+        default: '',
+        describe: 'to use a subdomain as the entry point, specify it here'
+    })
     .options('max-sockets', {
         default: 10,
         describe: 'maximum number of tcp sockets each client is allowed to establish at one time (the tunnels)'
@@ -29,7 +33,8 @@ if (argv.help) {
 
 var server = require('../server')({
     max_tcp_sockets: argv['max-sockets'],
-    secure: argv.secure
+    secure: argv.secure,
+    subdomain: argv.subdomain
 });
 
 server.listen(argv.port, function() {

--- a/server.js
+++ b/server.js
@@ -25,6 +25,9 @@ var stats = {
     tunnels: 0
 };
 
+// holds the CLI options
+var options;
+
 function maybe_bounce(req, res, bounce) {
     // without a hostname, we won't know who the request is for
     var hostname = req.headers.host;
@@ -33,11 +36,14 @@ function maybe_bounce(req, res, bounce) {
     }
 
     var subdomain = tldjs.getSubdomain(hostname);
-    if (!subdomain) {
+    if (!subdomain || subdomain === options.subdomain) {
         return false;
     }
 
     var client_id = subdomain;
+    if (options.subdomain) {
+        client_id = client_id.replace('.' + options.subdomain, '');
+    }
     var client = clients[client_id];
 
     // no such subdomain
@@ -140,9 +146,9 @@ function new_client(id, opt, cb) {
 }
 
 module.exports = function(opt) {
-    opt = opt || {};
+    options = opt || {};
 
-    var schema = opt.secure ? 'https' : 'http';
+    var schema = options.secure ? 'https' : 'http';
 
     var app = express();
 
@@ -181,7 +187,7 @@ module.exports = function(opt) {
 
         var req_id = rand_id();
         debug('making new client with id %s', req_id);
-        new_client(req_id, opt, function(err, info) {
+        new_client(req_id, options, function(err, info) {
             if (err) {
                 res.statusCode = 500;
                 return res.end(err.message);
@@ -208,7 +214,7 @@ module.exports = function(opt) {
         }
 
         debug('making new client with id %s', req_id);
-        new_client(req_id, opt, function(err, info) {
+        new_client(req_id, options, function(err, info) {
             if (err) {
                 return next(err);
             }


### PR DESCRIPTION
So you may remember me from like a year ago when I tried getting this to work and ended up giving up. I decided to revisit it recently and was getting new, but similar issues.

Ultimately, it appears that the server is _not_ configured to handle sub-subdomains. The server needs to _know_ that you're trying to use a subdomain as the entry point (i.e. the equivalent of `localtunnel.me`), otherwise it just thinks you're trying to connect to a proxy.

The code here allows you to specify a subdomain flag on the server side so that it knows about it.

---

As a full example, here's my `nginx` config (based on [your example](https://github.com/defunctzombie/localtunnel-server/blob/v0.0.8/devops/nginx/sites/localtunnel)):

``` nginx
proxy_http_version 1.1;

# http://nginx.org/en/docs/http/websocket.html
map $http_upgrade $connection_upgrade {
    default upgrade;
    ''      close;
}

upstream lt-server {
    server 127.0.0.1:1234;
}

server {
    listen 80;

    server_name .tunnel.example.com;

    location / {
        proxy_pass http://lt-server/;

        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header Host $http_host;
        proxy_set_header X-Forwarded-Proto http;
        proxy_set_header X-NginX-Proxy true;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $connection_upgrade;

        proxy_redirect off;
    }
}
```

Before this PR, if I tried to run the server with this:

``` bash
bin/server --port 1234
```

and ran this on the client:

``` bash
lt --host "http://tunnel.example.com" --port 1803 --local-host example.dev --subdomain myproject
```

with the intention of going to `http://myproject.tunnel.example.com` it **would not work**. The client would get a `502` response from the server and exit.

That's because on [line 36](https://github.com/defunctzombie/localtunnel-server/blob/v0.0.8/server.js#L36), is `false`, so the proxy is never created and on [line 40](https://github.com/defunctzombie/localtunnel-server/blob/v0.0.8/server.js#L40), `client_id` is `myproject.tunnel` when I want it to just be `myproject`.

In this PR, we add a `subdomain` option in the server options, so if we run this on the server:

``` bash
bin/server --port 1234 --subdomain tunnel
```

with the same command on the client, we now check to see if the subdomain in the request matches the `subdomain` parameter from the CLI, then it knows we want to create a client and thus does that. Then, when we go to our actual sub-subdomain we want the proxy to be at, `http://myproject.tunnel.example.com`, we remove `.{subdomain}` from the parsed subdomain value in the code, so the `client_id` is now `myproject` (because in this example `.tunnel` was removed) and we get the client `client_id` and everything works as expected.

I tried to add some tests, but the test workflow wasn't making it easy, as it's all based off of a single server configuration.
