### PR TITLE
added support multiple-level subdomain

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "stackup": "0.0.5",
     "stylish": "0.5.0",
     "taters": "1.0.0",
-    "tldjs": "1.5.1",
     "ws": "0.6.5"
   },
   "devDependencies": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,7 +5,7 @@ var localtunnel = require('localtunnel');
 
 var localtunnel_server = require('../server')();
 
-var lt_server_port
+var lt_server_port;
 
 test('setup localtunnel server', function(done) {
     var server = localtunnel_server.listen(function() {
@@ -79,7 +79,7 @@ test('query localtunnel server w/ ident', function(done) {
         host: 'localhost',
         port: lt_server_port,
         headers: {
-            host: hostname + '.tld'
+            host: hostname + ':' + lt_server_port
         },
         path: '/'
     }
@@ -112,7 +112,7 @@ test('request specific domain', function(done) {
     localtunnel(test._fake_port, opt, function(err, tunnel) {
         assert.ifError(err);
         var url = tunnel.url;
-        assert.ok(new RegExp('^http:\/\/.*localhost:' + lt_server_port + '$').test(url));
+        assert.ok(new RegExp('^http:\/\/.*\.localhost:' + lt_server_port + '$').test(url));
         test._fake_url = url;
         done(err);
     });

--- a/test/queue.js
+++ b/test/queue.js
@@ -61,7 +61,7 @@ test('query localtunnel server w/ ident', function(done) {
         port: lt_server_port,
         agent: false,
         headers: {
-            host: hostname + '.tld'
+            host: hostname + ':' + lt_server_port
         },
         path: '/'
     }

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -49,7 +49,7 @@ test('test websocket server request', function(done) {
     var hostname = url.parse(test._fake_url).hostname;
     var ws = new WebSocket('http://localhost:' + lt_server_port, {
         headers: {
-            host: hostname + '.tld'
+            host: hostname + ':' + lt_server_port
         }
     });
     ws.on('message', function(msg) {


### PR DESCRIPTION
Use full domain like "myproject.tunnel.example.com" as client's id instead of "myproject".

Combine sub_domain and current hostname as client's id when creating new client.
Check the clients object with full hostname when new request comes in.
