### PR TITLE
Allows dash characters in subdomains

### DIFF
--- a/server.js
+++ b/server.js
@@ -134,7 +134,7 @@ function maybe_bounce(req, res, sock, head) {
         var client_req = http.request(opt, function(client_res) {
             // write response code and headers
             res.writeHead(client_res.statusCode, client_res.headers);
-            
+
             client_res.pipe(res);
             on_finished(client_res, function(err) {
                 done();
@@ -221,7 +221,7 @@ module.exports = function(opt) {
         var req_id = req.params.req_id;
 
         // limit requested hostnames to 63 characters
-        if (! /^[a-z0-9]{4,63}$/.test(req_id)) {
+        if (! /^(?:[a-z0-9][a-z0-9\-]{4,63}[a-z0-9]|[a-z0-9]{4,63})$/.test(req_id)) {
             var err = new Error('Invalid subdomain. Subdomains must be lowercase and between 4 and 63 alphanumeric characters.');
             err.statusCode = 403;
             return next(err);

--- a/test/basic.js
+++ b/test/basic.js
@@ -118,6 +118,21 @@ test('request specific domain', function(done) {
     });
 });
 
+test('request domain with dash', function(done) {
+    var opt = {
+        host: 'http://localhost:' + lt_server_port,
+        subdomain: 'abcd-1234'
+    };
+
+    localtunnel(test._fake_port, opt, function(err, tunnel) {
+        assert.ifError(err);
+        var url = tunnel.url;
+        assert.ok(new RegExp('^http:\/\/.*localhost:' + lt_server_port + '$').test(url));
+        test._fake_url = url;
+        done(err);
+    });
+});
+
 test('request domain that is too long', function(done) {
     var opt = {
         host: 'http://localhost:' + lt_server_port,


### PR DESCRIPTION
localtunnel is a great tool!

There are many valid reasons to use a hyphenated subdomain.
For my use case with Twilio; localtunnel would be perfect if it allowed temporary domains with dashes.

This pull request allows dashes but does not allow a subdomain to start or end with a dash (as per RFC URI syntax spec).
