### PR TITLE
Use generated id in the returned url, if in use

### DIFF
--- a/server.js
+++ b/server.js
@@ -285,7 +285,7 @@ module.exports = function(opt) {
                 return next(err);
             }
 
-            const url = schema + '://' + req_id + '.' + req.headers.host;
+            const url = schema + '://' + info.id + '.' + req.headers.host;
             info.url = url;
             res.json(info);
         });


### PR DESCRIPTION
Seems like `new_client` may overwrite the `req_id` with a generated value, if the `id` already is in use by another client.

This causes an inconsistency between id and url. This is just a quick fix to make it consistent.

I suspect a proper fix would be some sort of `secret_token` returned the client that reserves the `id`. So that other clients can't use it. But that might be overkill, keeping the service simple seems like a good choice :)