### PR TITLE
Bump book version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-polyfill": "6.9.1",
     "babel-register": "6.9.0",
     "bluebird": "3.4.1",
-    "book": "1.3.1",
+    "book": "1.3.2",
     "book-git": "0.0.2",
     "book-raven": "1.2.0",
     "bookrc": "0.0.1",


### PR DESCRIPTION
Old version of book caused errors when running server on node v7. Fixes that.