### PR TITLE
Add option to set server listen address

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -17,6 +17,10 @@ const argv = optimist
         default: '80',
         describe: 'listen on this port for outside requests'
     })
+    .options('address', {
+        default: '0.0.0.0',
+        describe: 'IP address to bind to'
+    })
     .options('max-sockets', {
         default: 10,
         describe: 'maximum number of tcp sockets each client is allowed to establish at one time (the tunnels)'
@@ -33,7 +37,7 @@ const server = require('../server')({
     secure: argv.secure
 });
 
-server.listen(argv.port, () => {
+server.listen(argv.port, argv.address, () => {
     debug('server listening on port: %d', server.address().port);
 });
 


### PR DESCRIPTION
Since this server may run behind a reverse proxy like Nginx, it should be able to bind to localhost only rather than listening to the whole network.